### PR TITLE
Add short resource prefix

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -7,8 +7,10 @@ resource "random_string" "rand" {
 }
 
 locals {
-    resource_prefix_unclean = "${var.location_short}-${var.project_short}-${var.environment}-${random_string.rand.result}"
-    resource_prefix = lower(local.resource_prefix_unclean)
+    resource_prefix_partial = "${var.location_short}-${var.project_short}-${var.environment}-${random_string.rand.result}"
+    resource_prefix = lower(local.resource_prefix_partial)
+    resource_prefix_short_partial = substr(replace(lower("${var.location_short}${var.project_short}"), "/\\W/", ""),0, 14)
+    resource_prefix_short = "${local.resource_prefix_short_partial}${random_string.rand.result}"
     tags = tomap({
         "project"   = var.project
     })


### PR DESCRIPTION
Add short prefix to support storage accounts with max of 24 alphanumeric characters. Strips out anything that isn't alphanumeric.